### PR TITLE
Add websocket events for game state

### DIFF
--- a/SongRequestManagerV2/Bots/RequestBot.cs
+++ b/SongRequestManagerV2/Bots/RequestBot.cs
@@ -507,6 +507,7 @@ namespace SongRequestManagerV2.Bots
                 var autopick = RequestBotConfig.Instance.AutopickFirstSong || requestInfo.Flags.HasFlag(CmdFlags.Autopick);
                 // Filter out too many or too few results
                 if (!songs.Any()) {
+                    Logger.Info($"Song not found: {request}");
                     errorMessage = $"No results found for request \"{request}\"";
                 }
                 else if (!autopick && songs.Count >= 4) {

--- a/SongRequestManagerV2/Installes/SRMGameInstaller.cs
+++ b/SongRequestManagerV2/Installes/SRMGameInstaller.cs
@@ -7,6 +7,7 @@ namespace SongRequestManagerV2.Installes
         public override void InstallBindings()
         {
             _ = this.Container.BindInterfacesAndSelfTo<SongInfomationProvider>().AsCached().NonLazy();
+            _ = this.Container.BindInterfacesAndSelfTo<GameStateBroadcaster>().AsCached().NonLazy();
         }
     }
 }

--- a/SongRequestManagerV2/Interfaces/IChatManager.cs
+++ b/SongRequestManagerV2/Interfaces/IChatManager.cs
@@ -4,6 +4,7 @@ using CatCore.Services.Multiplexer;
 using CatCore.Services.Twitch.Interfaces;
 using SongRequestManagerV2.Bots;
 using SongRequestManagerV2.Models.Streamer.bot;
+using SongRequestManagerV2.SimpleJsons;
 using System.Collections.Concurrent;
 
 namespace SongRequestManagerV2.Interfaces
@@ -24,5 +25,6 @@ namespace SongRequestManagerV2.Interfaces
 
         void QueueChatMessage(string message);
         void SendMessageToStreamerbotServer(string message);
+        void SendEventToStreamerbotServer(string type, JSONObject data);
     }
 }

--- a/SongRequestManagerV2/Models/GameStateBroadcaster.cs
+++ b/SongRequestManagerV2/Models/GameStateBroadcaster.cs
@@ -1,0 +1,116 @@
+using SongRequestManagerV2.Interfaces;
+using SongRequestManagerV2.SimpleJsons;
+using System;
+using Zenject;
+using GlobalNamespace;
+
+namespace SongRequestManagerV2.Models
+{
+    public class GameStateBroadcaster : IInitializable, IDisposable
+    {
+        private readonly ScoreController _scoreController;
+        private readonly StandardLevelScenesTransitionSetupDataSO _transition;
+        private readonly GameplayCoreSceneSetupData _sceneData;
+        private readonly GameEnergyCounter _energyCounter;
+        private readonly IChatManager _chatManager;
+
+        [Inject]
+        public GameStateBroadcaster(
+            ScoreController scoreController,
+            GameEnergyCounter energyCounter,
+            StandardLevelScenesTransitionSetupDataSO transition,
+            GameplayCoreSceneSetupData sceneData,
+            IChatManager chatManager)
+        {
+            _scoreController = scoreController;
+            _energyCounter = energyCounter;
+            _transition = transition;
+            _sceneData = sceneData;
+            _chatManager = chatManager;
+        }
+
+        public void Initialize()
+        {
+            SendStartEvent();
+            if (_scoreController != null)
+            {
+                _scoreController.scoreDidChangeEvent += OnScoreChanged;
+            }
+            if (_transition != null)
+            {
+                _transition.didFinishEvent += OnLevelFinished;
+            }
+            if (_energyCounter != null)
+            {
+                _energyCounter.gameEnergyDidReach0Event += OnLevelFailed;
+            }
+        }
+
+        private void SendStartEvent()
+        {
+            var data = CreateSongData();
+            _chatManager.SendEventToStreamerbotServer("GameStarted", data);
+        }
+
+        private void OnScoreChanged(int score)
+        {
+            var data = CreateSongData();
+            data["score"] = score;
+            _chatManager.SendEventToStreamerbotServer("ScoreChanged", data);
+        }
+
+        private void OnLevelFailed()
+        {
+            var data = CreateSongData();
+            _chatManager.SendEventToStreamerbotServer("LevelFailed", data);
+            Cleanup();
+        }
+
+        private void OnLevelFinished(StandardLevelScenesTransitionSetupDataSO data, LevelCompletionResults results)
+        {
+            var json = CreateSongData();
+            json["cleared"] = results.levelEndStateType == LevelCompletionResults.LevelEndStateType.Cleared;
+            json["score"] = results.modifiedScore;
+            _chatManager.SendEventToStreamerbotServer("GameEnded", json);
+            Cleanup();
+        }
+
+        private JSONObject CreateSongData()
+        {
+            var json = new JSONObject();
+            if (SongInfomationProvider.CurrentSongLevel != null)
+            {
+                json["id"] = SongInfomationProvider.CurrentSongLevel["id"].Value;
+                json["name"] = SongInfomationProvider.CurrentSongLevel["metadata"]["songName"].Value;
+            }
+            else
+            {
+                json["id"] = _sceneData.beatmapKey.levelId;
+                json["name"] = _sceneData.previewBeatmapLevel.songName;
+            }
+            return json;
+        }
+
+        private void Cleanup()
+        {
+            if (_scoreController != null)
+            {
+                _scoreController.scoreDidChangeEvent -= OnScoreChanged;
+            }
+            if (_transition != null)
+            {
+                _transition.didFinishEvent -= OnLevelFinished;
+            }
+            if (_energyCounter != null)
+            {
+                _energyCounter.gameEnergyDidReach0Event -= OnLevelFailed;
+            }
+        }
+
+        public void Dispose()
+        {
+            Cleanup();
+        }
+    }
+}
+

--- a/SongRequestManagerV2/Utils/ChatManager.cs
+++ b/SongRequestManagerV2/Utils/ChatManager.cs
@@ -6,6 +6,7 @@ using SongRequestManagerV2.Bots;
 using SongRequestManagerV2.Configuration;
 using SongRequestManagerV2.Interfaces;
 using SongRequestManagerV2.Models.Streamer.bot;
+using SongRequestManagerV2.SimpleJsons;
 using System;
 using System.Collections.Concurrent;
 using Zenject;
@@ -149,6 +150,16 @@ namespace SongRequestManagerV2.Utils
             foreach (var json in jsons) {
                 _ = this.WebSocketClient?.SendAsync(json.ToString());
             }
+        }
+
+        public void SendEventToStreamerbotServer(string type, JSONObject data)
+        {
+            var json = new JSONObject();
+            json["event"] = type;
+            if (data != null) {
+                json.Add("data", data);
+            }
+            _ = this.WebSocketClient?.SendAsync(json.ToString());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add GameStateBroadcaster to broadcast song and score events via websocket
- extend ChatManager with `SendEventToStreamerbotServer`
- expose new method in `IChatManager`
- bind the broadcaster in `SRMGameInstaller`
- log when a requested song is not found

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c11fdcdbc83288783d3d85ad10cf8