### PR TITLE
Add difficulty setting and duplicate filter toggle

### DIFF
--- a/SongRequestManagerV2/Bots/RequestBot.cs
+++ b/SongRequestManagerV2/Bots/RequestBot.cs
@@ -947,7 +947,7 @@ namespace SongRequestManagerV2.Bots
                 return fast ? "X" : $"{metadata["songName"].Value} by {metadata["levelAuthorName"].Value} does not have a permitted mapper!";
             }
 
-            if (filter.HasFlag(SongFilter.Duplicate) && this.ListCollectionManager.Contains(s_duplicatelist, songid)) {
+            if (RequestBotConfig.Instance.EnableDuplicateFilter && filter.HasFlag(SongFilter.Duplicate) && this.ListCollectionManager.Contains(s_duplicatelist, songid)) {
                 return fast ? "X" : $"{metadata["songName"].Value} by  {metadata["levelAuthorName"].Value} already requested this session!";
             }
 

--- a/SongRequestManagerV2/Configuration/RequestBotConfig.cs
+++ b/SongRequestManagerV2/Configuration/RequestBotConfig.cs
@@ -39,6 +39,8 @@ namespace SongRequestManagerV2.Configuration
         public virtual bool PerformanceMode { get; set; } = false;
         public virtual bool NotifySound { get; set; } = false;
         public virtual int SoundVolume { get; set; } = 50;
+        public virtual string DefaultDifficulty { get; set; } = "Expert";
+        public virtual bool EnableDuplicateFilter { get; set; } = true;
         public virtual bool EnableAprilFool { get; set; } = false;
         [UseConverter(typeof(EnumConverter<LinkType>))]
         public virtual LinkType LinkType { get; set; } = LinkType.All;

--- a/SongRequestManagerV2/Views/SongRequestManagerSettings.bsml
+++ b/SongRequestManagerV2/Views/SongRequestManagerSettings.bsml
@@ -5,6 +5,8 @@
     <slider-setting text='Minimum rating' min='0' max='100' increment='.5' value='lowest-allowed-rating' integer-only='false' hover-hint='Minimum allowed song rating' ></slider-setting>
     <slider-setting text='Maximum Song Length' min='0' max='999' increment='1' value='maximum-song-length' integer-only='true' hover-hint='Longest allowed song length in minutes' ></slider-setting>
     <slider-setting text='Minimum NJS allowed' min='0' max='50' increment='1' value='minimum-njs' integer-only='true' hover-hint='Disallow songs below a certain NJS' ></slider-setting>
+    <dropdown-list-setting text='Default Difficulty' value='default-difficulty' choices='difficulties'></dropdown-list-setting>
+    <bool-setting text='Enable Duplicate Filter' value='enable-duplicate-filter' bind-value='true'></bool-setting>
     <bool-setting text='TTS Support' value='tts-support' bind-value='true' hover-hint='Add ! to all command outputs for TTS Filtering' ></bool-setting>
     <slider-setting text='User Request limit' min='0' max='10' increment='1' value='user-request-limit' integer-only='true' hover-hint='Maximum requests in queue at one time' ></slider-setting>
     <slider-setting text='Sub Request limit' min='0' max='10' increment='1' value='sub-request-limit' integer-only='true' hover-hint='Maximum requests in queue at one time' ></slider-setting>

--- a/SongRequestManagerV2/Views/SongRequestManagerSettings.cs
+++ b/SongRequestManagerV2/Views/SongRequestManagerSettings.cs
@@ -141,6 +141,31 @@ namespace SongRequestManagerV2.Views
 
             set => RequestBotConfig.Instance.SoundVolume = value;
         }
+        [UIValue("difficulties")]
+        public List<object> Difficulties { get; } = new List<object>()
+            {
+                "Easy",
+                "Normal",
+                "Hard",
+                "Expert",
+                "ExpertPlus"
+            };
+
+        [UIValue("default-difficulty")]
+        public string DefaultDifficulty
+        {
+            get => RequestBotConfig.Instance.DefaultDifficulty;
+
+            set => RequestBotConfig.Instance.DefaultDifficulty = value;
+        }
+
+        [UIValue("enable-duplicate-filter")]
+        public bool EnableDuplicateFilter
+        {
+            get => RequestBotConfig.Instance.EnableDuplicateFilter;
+
+            set => RequestBotConfig.Instance.EnableDuplicateFilter = value;
+        }
         [UIValue("pp-sarch")]
         public bool PPSerch
         {


### PR DESCRIPTION
## Summary
- add `DefaultDifficulty` and `EnableDuplicateFilter` settings
- expose those options in the settings UI
- skip duplicate check when disabled

## Testing
- `dotnet build SongRequestManagerV2.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c438c18248328885305635a4310bc